### PR TITLE
Fixed setting price in OrderItem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.5",
+        "phpunit/phpunit": "9.6",
         "vlucas/phpdotenv": "^2.4",
         "phpstan/phpstan": "^1.10.14",
         "phpstan/phpstan-deprecation-rules": "^1.0.0",

--- a/src/Models/OrderItem.php
+++ b/src/Models/OrderItem.php
@@ -55,7 +55,6 @@ class OrderItem extends Model
         $this->setQuantity($quantity);
         $this->setPrice($price);
         $this->setUrl($url);
-        $this->price = new Price(0, 0);
         $this->attributes = new Attributes();
     }
 


### PR DESCRIPTION
Found bug. Price of order item passed to constructor was always overwritten to 0.