### PR TITLE
Temporarily fix deprecation

### DIFF
--- a/src/Endpoints/AbstractRequest.php
+++ b/src/Endpoints/AbstractRequest.php
@@ -57,6 +57,7 @@ abstract class AbstractRequest implements \JsonSerializable
 
     abstract public function toArray(): array;
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->toArray();

--- a/src/Models/AbstractHolder.php
+++ b/src/Models/AbstractHolder.php
@@ -52,6 +52,7 @@ abstract class AbstractHolder implements \JsonSerializable
     /**
      * @return TEntry[]
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->toArray();

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -427,6 +427,7 @@ class Contact extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());

--- a/src/Models/ContactListStatus.php
+++ b/src/Models/ContactListStatus.php
@@ -73,6 +73,7 @@ class ContactListStatus extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());

--- a/src/Models/Contactlist.php
+++ b/src/Models/Contactlist.php
@@ -214,6 +214,7 @@ class Contactlist extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());

--- a/src/Models/CustomFieldDefinition.php
+++ b/src/Models/CustomFieldDefinition.php
@@ -148,6 +148,7 @@ class CustomFieldDefinition extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());

--- a/src/Models/CustomFieldOption.php
+++ b/src/Models/CustomFieldOption.php
@@ -108,6 +108,7 @@ class CustomFieldOption extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());

--- a/src/Models/CustomFieldValue.php
+++ b/src/Models/CustomFieldValue.php
@@ -104,6 +104,7 @@ class CustomFieldValue extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -37,6 +37,7 @@ abstract class Model implements \JsonSerializable
      */
     abstract public function toArray(): array;
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->toArray();

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -182,6 +182,7 @@ class Order extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());

--- a/tests/Endpoints/Contactlists/Search/RequestTest.php
+++ b/tests/Endpoints/Contactlists/Search/RequestTest.php
@@ -29,6 +29,7 @@ class RequestTest extends ApiStubTestCase
 
             // The query parameters to send
             $query = $value['query'];
+            $this->assertTrue(is_array($query), 'Query must be an array');
             $this->assertArrayHasKey('limit', $query);
             $this->assertArrayHasKey('offset', $query);
             $this->assertEquals(0, $query['offset'], 'The first page should have 0 offset');

--- a/tests/Endpoints/Contacts/Search/RequestTest.php
+++ b/tests/Endpoints/Contacts/Search/RequestTest.php
@@ -31,6 +31,7 @@ class RequestTest extends ApiStubTestCase
 
             // The query parameters to send
             $query = $value['query'];
+            $this->assertTrue(is_array($query), 'Query must be an array');
             $this->assertArrayHasKey('limit', $query);
             $this->assertArrayHasKey('offset', $query);
             $this->assertEquals(0, $query['offset'], 'The first page should have 0 offset');
@@ -57,6 +58,7 @@ class RequestTest extends ApiStubTestCase
 
             // The query parameters to send
             $query = $value['query'];
+            $this->assertTrue(is_array($query), 'Query must be an array');
             $this->assertArrayHasKey('limit', $query);
             $this->assertArrayHasKey('offset', $query);
             $this->assertEquals(50, $query['offset'], 'The second page should the limit value');

--- a/tests/Endpoints/CustomFields/Search/RequestTest.php
+++ b/tests/Endpoints/CustomFields/Search/RequestTest.php
@@ -32,6 +32,7 @@ class RequestTest extends ApiStubTestCase
 
             // The query parameters to send
             $query = $value['query'];
+            $this->assertTrue(is_array($query), 'Query must be an array');
             $this->assertArrayHasKey('limit', $query);
             $this->assertArrayHasKey('offset', $query);
             $this->assertEquals(0, $query['offset'], 'The first page should have 0 offset');
@@ -58,6 +59,7 @@ class RequestTest extends ApiStubTestCase
 
             // The query parameters to send
             $query = $value['query'];
+            $this->assertTrue(is_array($query), 'Query must be an array');
             $this->assertArrayHasKey('limit', $query);
             $this->assertArrayHasKey('offset', $query);
             $this->assertEquals(50, $query['offset'], 'The second page should the limit value');

--- a/tests/Mock/ModelMock.php
+++ b/tests/Mock/ModelMock.php
@@ -31,6 +31,7 @@ class ModelMock extends Model
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->removeEmptyValues($this->toArray());


### PR DESCRIPTION
PHP 8.2 Notice: `Deprecated: Return type of SmartEmailing\v3\Models\AbstractHolder::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`